### PR TITLE
feat: add Application instance in getPackageProviders method

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -34,7 +34,7 @@ class TestCase extends Orchestra
 	 *
 	 * @return array An array of service provider class names.
 	 */
-	protected function getPackageProviders($app): array
+	protected function getPackageProviders(Application $app): array
 	{
 		return [
 			APIResponseServiceProvider::class,


### PR DESCRIPTION
The **getPackageProviders** method should always receive an instance of Laravel’s Application class.